### PR TITLE
Fix RSAPSS salt length check

### DIFF
--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -606,8 +606,8 @@ func signRSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, opts crypto.Si
 	}
 
 	if pss, ok := opts.(*rsa.PSSOptions); ok {
-		if pss.SaltLength != rsa.PSSSaltLengthAuto && pss.SaltLength != len(digest) {
-			return nil, fmt.Errorf("PSS salt length %d is incorrect, expected rsa.PSSSaltLengthAuto or %d", pss.SaltLength, len(digest))
+		if pss.SaltLength != rsa.PSSSaltLengthAuto && pss.SaltLength != rsa.PSSSaltLengthEqualsHash && pss.SaltLength != len(digest) {
+			return nil, fmt.Errorf("PSS salt length %d is incorrect, expected rsa.PSSSaltLengthAuto, rsa.PSSSaltLengthEqualsHash or %d", pss.SaltLength, len(digest))
 		}
 		scheme.Alg = tpm2.AlgRSAPSS
 	}


### PR DESCRIPTION
This commit fixes the salt length check for RSAPSS. The previous logic was only validating `rsa.PSSSaltLengthAuto` or the length of the digest, e.g., 32 for SHA256. But `rsa.PSSSaltLengthEqualsHash` was invalid, and this should be equivalent to the length of the digest.

This commit allows using the TLS client handshake with an RSA key because the current logic in Go uses RSAPSS with RSA keys and sets the SaltLenth to rsa.PSSSaltLengthEqualsHash by default. See https://github.com/golang/go/blob/b702e0438ae9577dcc642ba7696a89799c86c8b7/src/crypto/tls/handshake_client_tls13.go#L658-L675