### PR TITLE
Explicitly set ECDSA signature scheme on Windows

### DIFF
--- a/attest/key_windows.go
+++ b/attest/key_windows.go
@@ -271,7 +271,7 @@ func (k *windowsAK20) sign(tb tpmBase, digest []byte, pub crypto.PublicKey, opts
 
 	switch p := pub.(type) {
 	case *ecdsa.PublicKey:
-		return signECDSA(rw, hnd, digest, p.Curve)
+		return signECDSA(rw, hnd, digest, p.Curve, opts)
 	case *rsa.PublicKey:
 		return signRSA(rw, hnd, digest, opts)
 	}


### PR DESCRIPTION
This sets a default on Windows, and also allows overriding it using `crypto.SignerOpts`. Also see [this commit](https://github.com/google/go-attestation/pull/343/commits/1702994f7d221d2b31e054fa308a5f2b35160116) as part of https://github.com/google/go-attestation/pull/343 doing the same with `opts`.

Currently it checks for `GOOS=windows`, but we could decide to set it explicitly on Linux too. Apparently `AlgNull` works OK on Linux, and not on Windows.