### PR TITLE
Don't drop leading zeroes when performing generic ECDSA signing

### DIFF
--- a/attest/wrapped_tpm20.go
+++ b/attest/wrapped_tpm20.go
@@ -613,7 +613,9 @@ func signECDSA(rw io.ReadWriter, key tpmutil.Handle, digest []byte, curve ellipt
 	if excess > 0 {
 		ret.Rsh(ret, uint(excess))
 	}
-	digest = ret.Bytes()
+	// call ret.FillBytes() here instead of ret.Bytes() to preserve leading zeroes
+	// that may have been dropped when converting the digest to an integer
+	digest = ret.FillBytes(digest)
 
 	sig, err := tpm2.Sign(rw, key, "", digest, nil, scheme)
 	if err != nil {


### PR DESCRIPTION
call ret.FillBytes() instead of ret.Bytes() to preserve leading zeroes that may have been dropped when converting the digest to an integer

Cherry-picked from https://github.com/google/go-attestation/pull/357